### PR TITLE
Forward JDWP debug port 5005 in Skaffold dev profiles

### DIFF
--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -83,6 +83,14 @@ profiles:
         path: /deploy/helm/releases/0/setValues
         value:
           connections.mongoHosts: "quarkus-mongo-rs0:27017"
+      # Forward JDWP debug port (Quarkus dev mode listens on 5005 by default)
+      - op: add
+        path: /portForward/-
+        value:
+          resourceType: deployment
+          resourceName: quarkus-deployment
+          port: 5005
+          localPort: 5005
 
   # In-cluster registry and buildx for remote dev
   # Activates automatically on: REMOTE_DEV=true skaffold dev


### PR DESCRIPTION
## Summary
- Add port 5005 forwarding to the `dev` and `remote-dev` Skaffold profiles, enabling IDE debugger attachment during `skaffold dev`
- Quarkus dev mode already starts a JDWP agent on port 5005 — this change simply exposes it via Skaffold port forwarding

## Test plan
- [ ] Run `skaffold dev -m quarkus` (or `REMOTE_DEV=true skaffold dev -m quarkus`)
- [ ] Verify port 5005 is forwarded to localhost
- [ ] Attach IntelliJ remote debugger to `localhost:5005` and confirm breakpoints hit

🤖 Generated with [Claude Code](https://claude.com/claude-code)